### PR TITLE
update BLAST URL for phytozome.

### DIFF
--- a/mason/site/toolbar/analyze.mas
+++ b/mason/site/toolbar/analyze.mas
@@ -13,7 +13,7 @@
 
     <li role="separator" class="divider"></li>
     <li class="dropdown-header">Sequence Analysis</li>
-    <li><a class="footer" href="http://www.phytozome.net/search.php?show=blast">BLAST</a></li>
+    <li><a class="footer" href="https://phytozome.jgi.doe.gov/pz/portal.html#!search?show=BLAST">BLAST</a></li>
     <li><a class="footer" href="http://vigs.solgenomics.net/">VIGS Tool</a></li>
     <li><a class="footer" href="https://cassavabase.org/jbrowse_cassavabase/?data=data/json/hapmap_variants">HapMap Jbrowse</a></li> 
 


### PR DESCRIPTION
The BLAST URL at Phytozome has changed and the Cassavabase BLAST link in the Analyze menu crashes. Added the new, correct link to the menu.